### PR TITLE
Create generic components for text, buttons, and a tinted image hero section

### DIFF
--- a/apps/frontend/src/components/footer/footer.tsx
+++ b/apps/frontend/src/components/footer/footer.tsx
@@ -1,6 +1,7 @@
 import { Bike } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { FacebookIcon, InstagramIcon } from '../icons/icons';
+import { OrangeButtonLink } from '../generic/buttons';
 
 export default function Footer() {
   return (
@@ -11,12 +12,14 @@ export default function Footer() {
           <p className="text-heading2 text-nowrap font-roc">the recyclery</p>
         </div>
         <div className="space-x-4">
-          <button className="bg-orange-500 hover:bg-orange-700 px-3 py-2 rounded-2xl text-white text-body2 cursor-pointer transition-colors font-brandon">
+          <OrangeButtonLink
+            to={
+              'https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=97B48AH3ZT92G'
+            }
+          >
             Donate
-          </button>
-          <button className="bg-orange-500 hover:bg-orange-700 px-3 py-2 rounded-2xl text-white text-body2 cursor-pointer transition-colors font-brandon">
-            Join Our Newsletter
-          </button>
+          </OrangeButtonLink>
+          <OrangeButtonLink to={'#'}>Join Our Newsletter</OrangeButtonLink>
         </div>
       </div>
       <div className="border-[1px] border-white/10" />

--- a/apps/frontend/src/components/generic/bg-image.tsx
+++ b/apps/frontend/src/components/generic/bg-image.tsx
@@ -1,0 +1,22 @@
+interface BgImageProps {
+  children: React.ReactNode;
+  image: string;
+  opacity?: number;
+  className?: string;
+}
+
+export function BgImage({ children, image, opacity = 0.4, className = '' }: BgImageProps) {
+  return (
+    <section
+      className={`flex flex-col justify-center items-center p-8 text-white text-center ${className}`}
+      style={{
+        background: `linear-gradient(rgba(0,0,0,${opacity}), rgba(0,0,0,${opacity})), url(${image})`,
+        backgroundPosition: 'center',
+        backgroundSize: 'cover',
+        backgroundRepeat: 'no-repeat',
+      }}
+    >
+      {children}
+    </section>
+  );
+}

--- a/apps/frontend/src/components/generic/buttons.tsx
+++ b/apps/frontend/src/components/generic/buttons.tsx
@@ -1,0 +1,51 @@
+import { Link } from 'react-router-dom';
+import React from 'react';
+
+export function BlueButtonLink({ to, children }: { to: string; children: React.ReactNode }) {
+  return (
+    <Link
+      to={to}
+      className="bg-blue-500 hover:bg-blue-700 px-3 py-2 rounded-2xl text-white text-body2 cursor-pointer transition-colors font-brandon"
+    >
+      {children}
+    </Link>
+  );
+}
+
+export function OrangeButtonLink({ to, children }: { to: string; children: React.ReactNode }) {
+  return (
+    <Link
+      to={to}
+      className="bg-orange-500 hover:bg-orange-700 px-3 py-2 rounded-2xl text-white text-body2 cursor-pointer transition-colors font-brandon"
+    >
+      {children}
+    </Link>
+  );
+}
+
+interface ButtonProps {
+  children: React.ReactNode;
+  onClick: () => void;
+}
+
+export function BlueButton({ children, onClick }: ButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="bg-blue-500 hover:bg-blue-700 px-3 py-2 rounded-2xl text-white text-body2 cursor-pointer transition-colors font-brandon"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function OrangeButton({ children, onClick }: ButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="bg-orange-500 hover:bg-orange-700 px-3 py-2 rounded-2xl text-white text-body2 cursor-pointer transition-colors font-brandon"
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/frontend/src/components/generic/styled-tags.tsx
+++ b/apps/frontend/src/components/generic/styled-tags.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export function H1({ children }: { children: React.ReactNode }) {
+  return <h1 className="text-7xl">{children}</h1>;
+}
+
+export function H2({ children }: { children: React.ReactNode }) {
+  return <h2 className="text-4xl text-orange-500">{children}</h2>;
+}
+
+export function H3({ children }: { children: React.ReactNode }) {
+  return <h3 className="text-2xl text-orange-500">{children}</h3>;
+}
+
+export function A({ to, children }: { to: string; children: React.ReactNode }) {
+  return (
+    <Link to={to} className="underline text-blue-500 hover:text-blue-800 transition">
+      {children}
+    </Link>
+  );
+}

--- a/apps/frontend/src/components/home/calendar-section.tsx
+++ b/apps/frontend/src/components/home/calendar-section.tsx
@@ -1,7 +1,9 @@
+import { H2 } from '../generic/styled-tags';
+
 function CalendarSection() {
   return (
     <section className="bg-tan-500 px-16 pt-10 pb-12">
-      <h2 className="text-4xl text-orange-500">our event calendar</h2>
+      <H2>our event calendar</H2>
       <p className="text-body2 pt-4 font-brandon">
         The calendar below shows all events for the Recyclery. Any upcoming events will also be
         updated here!

--- a/apps/frontend/src/components/home/hero-section.tsx
+++ b/apps/frontend/src/components/home/hero-section.tsx
@@ -1,35 +1,20 @@
-import { Link } from 'react-router-dom';
 import headerPoster from '../../assets/header-poster.jpg';
+import { H1 } from '../generic/styled-tags';
+import { BlueButtonLink, OrangeButtonLink } from '../generic/buttons';
+import { BgImage } from '../generic/bg-image';
 
 export default function HeroSection() {
   return (
-    <section
-      className="flex flex-col justify-center items-center p-8 min-h-[32rem] text-white text-center"
-      style={{
-        background: `linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4)), url(${headerPoster})`,
-        backgroundPosition: 'center',
-        backgroundSize: 'cover',
-      }}
-    >
-      <h1 className="text-7xl">the recyclery</h1>
+    <BgImage image={headerPoster} className="min-h-[32rem]">
+      <H1>the recyclery</H1>
       <p className="text-heading2 pt-8 max-w-[56rem] font-brandon">
         The Recyclery Collective is an educational bike shop that promotes sustainability by giving
         access to tools, skills, and opportunities for collaboration.
       </p>
       <div className="pt-6 space-x-4">
-        <Link
-          to="#"
-          className="bg-orange-500 hover:bg-orange-700 px-3 py-2 rounded-2xl text-white text-body2 cursor-pointer transition-colors font-brandon"
-        >
-          Join Our Newsletter
-        </Link>
-        <Link
-          to="https://therecyclery.square.site/"
-          className="bg-blue-500 hover:bg-blue-700 px-3 py-2 rounded-2xl text-white text-body2 cursor-pointer transition-colors font-brandon"
-        >
-          Shop Our Bikes
-        </Link>
+        <OrangeButtonLink to="#">Join Our Newsletter</OrangeButtonLink>
+        <BlueButtonLink to="https://therecyclery.square.site/">Shop Our Bikes</BlueButtonLink>
       </div>
-    </section>
+    </BgImage>
   );
 }

--- a/apps/frontend/src/components/home/program.tsx
+++ b/apps/frontend/src/components/home/program.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { H3 } from '../generic/styled-tags';
+import { BlueButtonLink } from '../generic/buttons';
 
 interface ProgramProps {
   children: ReactNode;
@@ -10,14 +11,9 @@ interface ProgramProps {
 export default function Program({ children, title, learnMoreLink }: ProgramProps) {
   return (
     <div className="space-y-4">
-      <h3 className="text-2xl text-orange-500">{title}</h3>
+      <H3>{title}</H3>
       <p className="text-body2 font-brandon">{children}</p>
-      <Link
-        to={learnMoreLink}
-        className="bg-blue-500 hover:bg-blue-700 px-3 py-2 rounded-2xl text-white text-body2 cursor-pointer transition-colors font-brandon"
-      >
-        Learn More
-      </Link>
+      <BlueButtonLink to={learnMoreLink}>Learn More</BlueButtonLink>
     </div>
   );
 }

--- a/apps/frontend/src/components/home/programs-section.tsx
+++ b/apps/frontend/src/components/home/programs-section.tsx
@@ -1,20 +1,18 @@
-import { Link } from 'react-router-dom';
 import Program from './program';
+import { A, H2 } from '../generic/styled-tags';
 
 export default function ProgramsSection() {
   return (
     <section className="bg-background px-16 pt-10 pb-16">
-      <h2 className="text-4xl text-orange-500">our programs</h2>
+      <H2>our programs</H2>
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 pt-8">
         <Program title={'open shop'} learnMoreLink={'/our-programs/openshop'}>
           You can work on your own bike during Open Shop. All levels of experience are welcome.
           <br />
           <br />
           For femme, trans, women and non-binary community,{' '}
-          <Link to="/our-programs/ftwnb" className="underline hover:text-blue-600 transition">
-            FTWN-B Shop Time
-          </Link>{' '}
-          (Sundays 3-6pm) is another opportunity to work on your bike.
+          <A to="/our-programs/ftwnb">FTWN-B Shop Time</A> (Sundays 3-6pm) is another opportunity to
+          work on your bike.
           <br />
           <br />
           <u>HOURS:</u>
@@ -47,22 +45,13 @@ export default function ProgramsSection() {
           Overhaul Class. The classes are meant for adults, and you should bring your own bike.
           <br />
           <br />
-          To register, visit our{' '}
-          <Link
-            to="https://therecyclery.square.site/"
-            className="underline hover:text-blue-600 transition"
-          >
-            online shop
-          </Link>{' '}
-          (Sundays 3-6pm) is another opportunity to work on your bike.
+          To register, visit our <A to="https://therecyclery.square.site/">online shop</A> (Sundays
+          3-6pm) is another opportunity to work on your bike.
           <br />
           <br />
           <u>HOURS:</u>
           <br />
-          Variable, see{' '}
-          <Link to="/our-programs/classes" className="underline hover:text-blue-600 transition">
-            sign up page
-          </Link>
+          Variable, see <A to="/our-programs/classes">sign up page</A>
         </Program>
       </div>
     </section>

--- a/apps/frontend/src/components/home/video-section.tsx
+++ b/apps/frontend/src/components/home/video-section.tsx
@@ -1,7 +1,9 @@
+import { H2 } from '../generic/styled-tags';
+
 export default function VideoSection() {
   return (
     <section className="bg-background px-6 pt-10 pb-12 flex flex-col items-center">
-      <h2 className="text-4xl text-orange-500">introductory video</h2>
+      <H2>introductory video</H2>
       <iframe
         className="w-full md:w-[600px] lg:w-[900px] h-[300px] md:h-[337px] lg:h-[506px] mt-6"
         src="https://www.youtube.com/embed/p_mOukqz0WM"

--- a/apps/frontend/src/components/navigation/nav-bar.tsx
+++ b/apps/frontend/src/components/navigation/nav-bar.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import NavbarItem from './nav-bar-item';
 import { AboutUsSubItems, OurProgramsSubItems, SupportUsSubItems } from './nav-content';
 import SideMenu from './side-menu';
+import { BlueButtonLink } from '../generic/buttons';
 
 export type NavbarSubMenuItemType = {
   icon: ReactNode;
@@ -30,16 +31,10 @@ export default function NavBar() {
           <NavbarItem title="Support Us" subItems={SupportUsSubItems} />
         </div>
         <div className="space-x-4 hidden lg:block">
-          <Link to="https://therecyclery.square.site/">
-            <button className="bg-blue-500 hover:bg-blue-600 px-3 py-2 rounded-2xl text-white cursor-pointer transition-colors font-brandon">
-              Shop For Bikes
-            </button>
-          </Link>
-          <Link to="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=97B48AH3ZT92G">
-            <button className="bg-blue-500 hover:bg-blue-600 px-3 py-2 rounded-2xl text-white cursor-pointer transition-colors font-brandon">
-              Donate
-            </button>
-          </Link>
+          <BlueButtonLink to="https://therecyclery.square.site/">Shop For Bikes</BlueButtonLink>
+          <BlueButtonLink to="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=97B48AH3ZT92G">
+            Donate
+          </BlueButtonLink>
         </div>
         <div className="lg:hidden block">
           <button


### PR DESCRIPTION
## What?
Created generic components for different text sizes, orange and blue buttons, and tinted background image hero section. Used the components in the home page, navbar, and footer.
## Why?
Using generic `components` makes the code more readable, more consistent, and easier to change in the future.
## How?
- Created the generic components in `frontend/src/components/generic`
- All components can be used with children like so: `<H1>children</H1>`
- `OrangeButtonLink` and `BlueButtonLink` are `Link` components with a `to` field, and `OrangeButton` and `BlueButton` are `button`s with an `onclick` field.
- `BgImage` is a section tag a background image, optional `opacity` (default 0.4), and optional `className`. Higher opacity means darker. Use `className` to change the height, etc.