### PR TITLE
Standardize existing pages and improve generic components

### DIFF
--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -26,6 +26,10 @@
   }
 }
 
+html {
+    scroll-behavior: smooth;
+}
+
 .card {
   padding: 2em;
 }

--- a/apps/frontend/src/components/classes/class-description.tsx
+++ b/apps/frontend/src/components/classes/class-description.tsx
@@ -1,38 +1,35 @@
-import { H2 } from '../generic/styled-tags';
+import { H2, Section } from '../generic/styled-tags';
 
-export default function ClassDescription () {
-    return (
-        <section className="bg-background px-16 pt-16 pb-20">
-            <section className="mb-12">
-                <p className="text-xl  font-brandon leading-relaxed mb-6">
-                    If you have never fixed a flat tire before, we recommend taking the Tune Up Class first.
-                    <br /><br />
-                    We can provide a bike that will be donated locally after the overhaul is complete, but we also 
-                    encourage students to bring their own!
-                </p>
-                <br />
-                <H2>mechanics 101</H2>
-                <br />
-                <p className="text-xl font-brandon leading-relaxed">
-                    Learn the basics with our seasoned mechanics for a two-session bicycle maintenance course. 
-                    Give your own geared bike a tune-up and become educated on proper terminology for componentry 
-                    and tools, the basics of fixing flat tires, chain replacement, and brake & shifting adjustments. 
-                    We keep classes small, so grab your limited spot while you can!
-                </p>
-            </section>
+export default function ClassDescription() {
+  return (
+    <Section>
+      <section className="mb-12">
+        <p className="text-lg font-brandon mb-6">
+          If you have never fixed a flat tire before, we recommend taking the Tune Up Class first.
+          <br />
+          <br />
+          We can provide a bike that will be donated locally after the overhaul is complete, but we
+          also encourage students to bring their own!
+        </p>
+        <br />
+        <H2>mechanics 101</H2>
+        <p className="text-lg font-brandon">
+          Learn the basics with our seasoned mechanics for a two-session bicycle maintenance course.
+          Give your own geared bike a tune-up and become educated on proper terminology for
+          componentry and tools, the basics of fixing flat tires, chain replacement, and brake &
+          shifting adjustments. We keep classes small, so grab your limited spot while you can!
+        </p>
+      </section>
 
-            <section className="mb-12">
-                <br />
-                <H2>overhaul class</H2>
-                <br />
-                <p className="text-xl font-brandon leading-relaxed">
-                    Over six sessions, seasoned Recyclery mechanic instructor(s) will walk you through how to 
-                    disassemble, reassemble, and adjust all major mechanical systems of your bicycle in addition 
-                    to answering any questions you have along the way!
-                </p>
-            </section>     
-        </section>
-
-        
-    );
+      <section className="mb-12">
+        <br />
+        <H2>overhaul class</H2>
+        <p className="text-lg font-brandon">
+          Over six sessions, seasoned Recyclery mechanic instructor(s) will walk you through how to
+          disassemble, reassemble, and adjust all major mechanical systems of your bicycle in
+          addition to answering any questions you have along the way!
+        </p>
+      </section>
+    </Section>
+  );
 }

--- a/apps/frontend/src/components/classes/class-hero.tsx
+++ b/apps/frontend/src/components/classes/class-hero.tsx
@@ -3,17 +3,13 @@ import { BgImage } from '../generic/bg-image';
 import headerImage from '../classes/header-image.png';
 
 export default function ClassHero() {
-    return (
-        <BgImage image={headerImage} className="min-h-[32rem]">
-            <main className="max-w-screen-xl mx-auto p-4">
-                <section className="mb-8 text-center">
-                    <H1>Classes</H1>
-                    <p className="text-heading2 pt-8 max-w-[56rem] font-brandon">
-                    We teach bicycle maintenance through our introductory Tune Up Class and our advanced
-                    Overhaul Class.
-                    </p>
-                </section>
-            </main>
-        </BgImage>
-    );
+  return (
+    <BgImage image={headerImage} className="min-h-[32rem]">
+      <H1>classes</H1>
+      <p className="text-heading2 pt-8 max-w-[56rem] font-brandon">
+        We teach bicycle maintenance through our introductory Tune Up Class and our advanced
+        Overhaul Class.
+      </p>
+    </BgImage>
+  );
 }

--- a/apps/frontend/src/components/classes/class-signup.tsx
+++ b/apps/frontend/src/components/classes/class-signup.tsx
@@ -1,35 +1,28 @@
-import { H2 } from '../generic/styled-tags';
+import { H2, Section } from '../generic/styled-tags';
 import ClassCard from './class-card';
 
-
-// #F0D9C2
-
-export default function ClassSignup () {
-    return (
-        <section className="bg-tan-500 px-16 pt-10 pb-16">
-            <section className="text-center mb-8">
-            <H2>sign up</H2>
-        </section>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            <ClassCard
-            title="Mechanics 101"
-            level="beginner"
-            sessions="Six Sessions"
-            description="Learn all major mechanical systems of your bicycle."
-            buttonText="Sign Up"
-            buttonLink="https://therecyclery.square.site/product/bike-maintenance-101/1905?cp=true&sa=false&sbp=false&q=false&category_id=23"
-            />
-            <ClassCard
-            title="Overhaul Class"
-            level="advanced"
-            sessions="Two Sessions"
-            description="Learn basics bicycle maintenance."
-            buttonText="Sign Up"
-            buttonLink="https://therecyclery.square.site/product/overhaul-class/1027?cp=true&sa=false&sbp=false&q=false&category_id=23"
-            />
+export default function ClassSignup() {
+  return (
+    <Section className="text-center" tan>
+      <H2>sign up</H2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <ClassCard
+          title="Mechanics 101"
+          level="beginner"
+          sessions="Six Sessions"
+          description="Learn all major mechanical systems of your bicycle."
+          buttonText="Sign Up"
+          buttonLink="https://therecyclery.square.site/product/bike-maintenance-101/1905?cp=true&sa=false&sbp=false&q=false&category_id=23"
+        />
+        <ClassCard
+          title="Overhaul Class"
+          level="advanced"
+          sessions="Two Sessions"
+          description="Learn basics bicycle maintenance."
+          buttonText="Sign Up"
+          buttonLink="https://therecyclery.square.site/product/overhaul-class/1027?cp=true&sa=false&sbp=false&q=false&category_id=23"
+        />
       </div>
-    </section>
- 
-    );
+    </Section>
+  );
 }
-    

--- a/apps/frontend/src/components/generic/styled-tags.tsx
+++ b/apps/frontend/src/components/generic/styled-tags.tsx
@@ -1,22 +1,48 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-export function H1({ children }: { children: React.ReactNode }) {
-  return <h1 className="sm:text-7xl text-5xl">{children}</h1>;
+export function H1({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <h1 className={`sm:text-7xl text-5xl ${className}`}>{children}</h1>;
 }
 
-export function H2({ children }: { children: React.ReactNode }) {
-  return <h2 className="text-2xl sm:text-4xl text-orange-500">{children}</h2>;
+export function H2({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <h2 className={`text-3xl sm:text-4xl mb-8 text-orange-500 ${className}`}>{children}</h2>;
 }
 
-export function H3({ children }: { children: React.ReactNode }) {
-  return <h3 className="text-xl sm:text-2xl text-orange-500">{children}</h3>;
+export function H3({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <h3 className={`text-xl sm:text-2xl text-orange-500 ${className}`}>{children}</h3>;
 }
 
-export function A({ to, children }: { to: string; children: React.ReactNode }) {
+interface AProps {
+  to: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function A({ to, children, className }: AProps) {
   return (
-    <Link to={to} className="underline text-blue-500 hover:text-blue-800 transition">
+    <Link to={to} className={`underline text-blue-500 hover:text-blue-800 transition ${className}`}>
       {children}
     </Link>
+  );
+}
+
+interface SectionProps {
+  children: React.ReactNode;
+  className?: string;
+  id?: string;
+  style?: React.CSSProperties;
+  tan?: boolean;
+}
+
+export function Section({ children, className, id, style, tan = false }: SectionProps) {
+  return (
+    <section
+      id={id}
+      className={`${tan ? 'bg-tan-500' : 'bg-background'} px-8 md:px-16 lg:px-24 xl:px-36 py-16 ${className}`}
+      style={style}
+    >
+      {children}
+    </section>
   );
 }

--- a/apps/frontend/src/components/home/calendar-section.tsx
+++ b/apps/frontend/src/components/home/calendar-section.tsx
@@ -1,10 +1,10 @@
-import { H2 } from '../generic/styled-tags';
+import { H2, Section } from '../generic/styled-tags';
 
 function CalendarSection() {
   return (
-    <section className="bg-tan-500 px-16 pt-10 pb-12">
-      <H2>our event calendar</H2>
-      <p className="text-body2 pt-4 font-brandon">
+    <Section tan>
+      <H2 className="!mb-4">our event calendar</H2>
+      <p className="text-body2 font-brandon">
         The calendar below shows all events for the Recyclery. Any upcoming events will also be
         updated here!
       </p>
@@ -20,7 +20,7 @@ function CalendarSection() {
         frameBorder="0"
         scrolling="no"
       ></iframe>
-    </section>
+    </Section>
   );
 }
 

--- a/apps/frontend/src/components/home/programs-section.tsx
+++ b/apps/frontend/src/components/home/programs-section.tsx
@@ -1,11 +1,11 @@
 import Program from './program';
-import { A, H2 } from '../generic/styled-tags';
+import { A, H2, Section } from '../generic/styled-tags';
 
 export default function ProgramsSection() {
   return (
-    <section className="bg-background px-16 pt-10 pb-16">
+    <Section>
       <H2>our programs</H2>
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 pt-8">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
         <Program title={'open shop'} learnMoreLink={'/our-programs/openshop'}>
           You can work on your own bike during Open Shop. All levels of experience are welcome.
           <br />
@@ -54,6 +54,6 @@ export default function ProgramsSection() {
           Variable, see <A to="/our-programs/classes">sign up page</A>
         </Program>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/apps/frontend/src/components/home/video-section.tsx
+++ b/apps/frontend/src/components/home/video-section.tsx
@@ -1,11 +1,11 @@
-import { H2 } from '../generic/styled-tags';
+import { H2, Section } from '../generic/styled-tags';
 
 export default function VideoSection() {
   return (
-    <section className="bg-background px-6 pt-10 pb-12 flex flex-col items-center">
+    <Section className="bg-background px-6 pt-10 pb-12 flex flex-col items-center">
       <H2>introductory video</H2>
       <iframe
-        className="w-full md:w-[600px] lg:w-[900px] h-[300px] md:h-[337px] lg:h-[506px] mt-6"
+        className="w-full md:w-[600px] lg:w-[900px] h-[300px] md:h-[337px] lg:h-[506px]"
         src="https://www.youtube.com/embed/p_mOukqz0WM"
         title="Recyclery"
         frameBorder="0"
@@ -13,6 +13,6 @@ export default function VideoSection() {
         referrerPolicy="strict-origin-when-cross-origin"
         allowFullScreen
       ></iframe>
-    </section>
+    </Section>
   );
 }

--- a/apps/frontend/src/components/our-programs/freecyclery/about-section.tsx
+++ b/apps/frontend/src/components/our-programs/freecyclery/about-section.tsx
@@ -1,13 +1,13 @@
-import { H2 } from '../../generic/styled-tags';
+import { H2, Section } from '../../generic/styled-tags';
 import earnABike from '../../../assets/images/our-programs/freecyclery/earn-a-bike.jpg';
 import squigglyLine from '../../../assets/images/our-programs/freecyclery/squiggly-line.svg';
 
 export default function AboutSection() {
   return (
-    <section className="bg-background px-8 md:px-24 py-20 lg:py-0 lg:grid lg:grid-cols-2 gap-24 items-center justify-items-center">
+    <Section className="lg:py-0 lg:grid lg:grid-cols-2 gap-24 items-center justify-items-center">
       <div>
         <H2>about our program</H2>
-        <p className="text-body2 pt-8 font-brandon">
+        <p className="text-body2 font-brandon">
           We work with local social service agencies to connect people in need with a free bike that
           was serviced by volunteer mechanics and checked over by a Recyclery mechanic.
         </p>
@@ -24,6 +24,6 @@ export default function AboutSection() {
           className="rounded-xl h-[20rem] lg:absolute lg:left-[50%] lg:translate-x-[-50%] lg:translate-y-[5rem] lg:z-10"
         />
       </div>
-    </section>
+    </Section>
   );
 }

--- a/apps/frontend/src/components/our-programs/freecyclery/earn-a-bike.tsx
+++ b/apps/frontend/src/components/our-programs/freecyclery/earn-a-bike.tsx
@@ -1,13 +1,13 @@
-import { H2 } from '../../generic/styled-tags';
+import { H2, Section } from '../../generic/styled-tags';
 import DashedBorder from './dashed-border';
 import { Link } from 'react-router-dom';
 import React from 'react';
 
 export default function EarnABike() {
   return (
-    <section className="bg-tan-500 px-8 md:px-16 py-16 flex flex-col items-center text-center">
+    <Section className="flex flex-col items-center text-center" tan>
       <H2>earn-a-bike fellowship programs</H2>
-      <p className="text-body1 mt-8 font-brandon md:px-12 lg:max-w-[48rem]">
+      <p className="text-body1 font-brandon md:px-12 lg:max-w-[48rem]">
         As an alternative to a referral from a partner organization, we offer opportunities for
         adults and youth to earn a Freecyclery bike through our Earn-a-Bike Fellowship programs.
       </p>
@@ -41,6 +41,6 @@ export default function EarnABike() {
           </DashedBorder>
         </div>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/apps/frontend/src/components/our-programs/freecyclery/how-it-works.tsx
+++ b/apps/frontend/src/components/our-programs/freecyclery/how-it-works.tsx
@@ -1,13 +1,13 @@
 import { Bike, Megaphone } from 'lucide-react';
-import { A, H2 } from '../../generic/styled-tags';
+import { A, H2, Section } from '../../generic/styled-tags';
 import circleSketch from '../../../assets/images/our-programs/freecyclery/circle-sketch.svg';
 import arrow from '../../../assets/images/our-programs/freecyclery/arrow.svg';
 
 export default function HowItWorks() {
   return (
-    <section className="bg-tan-500 px-8 md:px-16 py-16 flex flex-col items-center">
+    <Section className="flex flex-col items-center" tan>
       <H2>how does it work?</H2>
-      <p className="text-body1 pt-4 font-brandon">
+      <p className="text-body1 font-brandon">
         The Freecyclery Program provides
         <span
           className="relative inline-flex items-center justify-center w-12 h-12"
@@ -32,8 +32,11 @@ export default function HowItWorks() {
           </div>
           <h3 className="text-subheading1">Referrals</h3>
           <p className="text-body2 pt-2 font-brandon">
-            Our dedicated <A to="#">Freecyclery Partners</A> refer individuals to us to receive a
-            free bicycle.
+            Our dedicated{' '}
+            <a href="#partners" className="underline text-blue-500 hover:text-blue-800 transition">
+              Freecyclery Partners
+            </a>{' '}
+            refer individuals to us to receive a free bicycle.
           </p>
         </div>
         <div>
@@ -52,6 +55,6 @@ export default function HowItWorks() {
           </p>
         </div>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/apps/frontend/src/components/our-programs/freecyclery/make-referral.tsx
+++ b/apps/frontend/src/components/our-programs/freecyclery/make-referral.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Mail } from 'lucide-react';
-import { A, H2 } from '../../generic/styled-tags';
+import { A, H2, Section } from '../../generic/styled-tags';
 import deliveryBike from '../../../assets/images/our-programs/freecyclery/delivery-bike.png';
 import squigglyCross from '../../../assets/images/our-programs/freecyclery/squiggly-cross.svg';
 import DashedBorder from './dashed-border';
@@ -8,14 +8,14 @@ import Accordion from './accordion';
 
 export default function MakeReferral() {
   return (
-    <section
-      className="px-8 md:px-16 py-16 flex flex-col items-center bg-background [background-size:0] md:[background-size:100%_100%]"
+    <Section
+      className="flex flex-col items-center [background-size:0] md:[background-size:100%_100%]"
       style={{
         backgroundImage: `url("${squigglyCross}")`,
       }}
     >
       <H2>make a referral today</H2>
-      <div className="bg-tan-500 max-w-[64rem] mt-8 p-2 rounded-[16px]">
+      <div className="bg-tan-500 max-w-[64rem] p-2 rounded-[16px]">
         <DashedBorder className="grid md:grid-cols-2 gap-6 md:gap-4 px-8 py-12 items-center">
           <div>
             <h3 className="text-heading2">contact us</h3>
@@ -67,6 +67,6 @@ export default function MakeReferral() {
         </A>{' '}
         or contact us! We are always open to exploring new collaborations.
       </p>
-    </section>
+    </Section>
   );
 }

--- a/apps/frontend/src/components/our-programs/freecyclery/partners.tsx
+++ b/apps/frontend/src/components/our-programs/freecyclery/partners.tsx
@@ -1,4 +1,4 @@
-import { H2 } from '../../generic/styled-tags';
+import { H2, Section } from '../../generic/styled-tags';
 import React from 'react';
 
 export default function Partners() {
@@ -14,13 +14,13 @@ export default function Partners() {
   });
 
   return (
-    <section className="bg-background px-8 md:px-16 py-16 flex flex-col items-center text-center">
+    <Section id="partners" className="flex flex-col items-center text-center">
       <H2>freecyclery partners</H2>
-      <div className="flex justify-center flex-wrap gap-x-12 gap-y-2 mt-8 max-w-[72rem]">
+      <div className="flex justify-center flex-wrap gap-x-12 gap-y-2 max-w-[72rem]">
         {images.map(image => (
           <img src={image.src} alt={image.alt} className="max-h-28 object-contain" />
         ))}
       </div>
-    </section>
+    </Section>
   );
 }

--- a/apps/frontend/src/pages/about-us/what/what.tsx
+++ b/apps/frontend/src/pages/about-us/what/what.tsx
@@ -1,7 +1,7 @@
 import WhatHero from '../../../assets/images/about-us/what/what-hero.png';
 import WhatSection1 from '../../../assets/images/about-us/what/what-section-1.png';
 import { BgImage } from '../../../components/generic/bg-image';
-import { H1, H2, H3 } from '../../../components/generic/styled-tags';
+import { H1, H2, H3, Section } from '../../../components/generic/styled-tags';
 
 function WhatWeDo() {
   return (
@@ -13,7 +13,7 @@ function WhatWeDo() {
           as well as our milestone of refurbishing 10,000 bikes.
         </p>
       </BgImage>
-      <section className="w-full lg:px-[120px] md:px-[96px] px-[64px] py-9 flex md:flex-row-reverse flex-col justify-center items-center md:gap-16 gap-8">
+      <Section className="flex md:flex-row-reverse flex-col justify-center items-center md:gap-16 gap-8">
         <div className="flex flex-col gap-6">
           <div>
             <H2>our mission</H2>
@@ -35,8 +35,8 @@ function WhatWeDo() {
           alt="Person with bike"
           className="max-w-[300px] w-full rounded-2xl object-fit"
         />
-      </section>
-      <section className="w-full lg:px-[120px] md:px-[96px] px-[64px] py-9 bg-tan-500">
+      </Section>
+      <Section tan>
         <H2>our core values</H2>
         <div className="flex flex-col gap-8">
           <div className="flex md:flex-row flex-col justify-center items-start gap-8">
@@ -92,8 +92,8 @@ function WhatWeDo() {
             </div>
           </div>
         </div>
-      </section>
-      <section className="w-full lg:px-[120px] md:px-[96px] px-[64px] py-9">
+      </Section>
+      <Section>
         <H2>testimonials</H2>
         <div className="flex lg:flex-row flex-col justify-center items-center gap-8 lg:h-[250px]">
           <div className="h-full flex-1 flex flex-col justify-between space-y-8 lg:space-y-0">
@@ -121,7 +121,7 @@ function WhatWeDo() {
             </div>
           </div>
         </div>
-      </section>
+      </Section>
     </main>
   );
 }

--- a/apps/frontend/src/pages/about-us/who/who.tsx
+++ b/apps/frontend/src/pages/about-us/who/who.tsx
@@ -1,7 +1,7 @@
 import WhoHero from '../../../assets/images/about-us/who/who-hero.png';
 import MemberCard, { MemberCardProps } from '../../../components/about-us/member-card';
 import { BgImage } from '../../../components/generic/bg-image';
-import { H1, H2 } from '../../../components/generic/styled-tags';
+import { H1, H2, Section } from '../../../components/generic/styled-tags';
 
 const members: MemberCardProps[] = [
   {
@@ -51,14 +51,14 @@ function WhoWeAre() {
           as well as our milestone of refurbishing 10,000 bikes.
         </p>
       </BgImage>
-      <section className="w-full lg:px-[120px] md:px-[96px] px-[64px] py-9">
+      <Section>
         <H2>staff and collective members</H2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {members.map(member => {
             return <MemberCard {...member} />;
           })}
         </div>
-      </section>
+      </Section>
     </main>
   );
 }

--- a/apps/frontend/src/pages/our-programs/openshop/openshop.tsx
+++ b/apps/frontend/src/pages/our-programs/openshop/openshop.tsx
@@ -1,7 +1,7 @@
 import OpenshopHero from '../../../assets/images/our-programs/openshop/openshop-hero.png';
 import OpenshopSection1 from '../../../assets/images/our-programs/openshop/openshop-section-1.png';
 import { BgImage } from '../../../components/generic/bg-image';
-import { A, H1, H2 } from '../../../components/generic/styled-tags';
+import { A, H1, H2, Section } from '../../../components/generic/styled-tags';
 
 function OpenShop() {
   return (
@@ -12,7 +12,7 @@ function OpenShop() {
           Use our tools to fix your own bike with the instruction of Recyclery mechanics.
         </p>
       </BgImage>
-      <section className="w-full lg:px-[120px] md:px-[96px] px-[64px] py-9 flex lg:flex-row flex-col justify-center items-center lg:gap-16 gap-8">
+      <Section className="flex lg:flex-row flex-col justify-center items-center lg:gap-16 gap-8">
         <div className="flex flex-col gap-6">
           <div>
             <H2>what is open shop?</H2>
@@ -43,8 +43,8 @@ function OpenShop() {
           alt="Two people working on a bike"
           className="max-w-[450px] w-full rounded-2xl object-fit"
         />
-      </section>
-      <section className="w-full lg:px-[120px] md:px-[96px] px-[64px] py-9 bg-tan-500">
+      </Section>
+      <Section tan>
         <H2>hours</H2>
         <div className="space-y-4 font-brandon">
           <ul>
@@ -58,7 +58,7 @@ function OpenShop() {
             <A to="https://therecyclery.bigcartel.com/">online shop.</A>
           </p>
         </div>
-      </section>
+      </Section>
     </main>
   );
 }


### PR DESCRIPTION
## What?
Create section component and use it in all existing pages; make all styled tags customizable; add a default ``mb-8`` to ``H2``; fix problems in freecyclery and classes pages.
## Why?
Using a section component makes margins consistent across pages; making styled tags more customizable makes them easier to use.
## How?
- Created a `Section` component. It can be used like a normal `section` component and has responsive padding by default. Default background color is off-white; use ``<Section tan>`` to make it tan. `className`, `id`, and `style` can also be customized.
- Updated styled tags (e.g. `H1`, `H2`, `A`, etc.) to have a className prop so that their styles can be customized using tailwind. **Use an exclamation mark to override default styles** (e.g. `className="!text-black"`).
- I made `mb-8` the default for the `H2` tag to ensure consistent spacing.
- I also slightly increased the text size for `H2` and `H3` on mobile; it was too small before.
- Updated all existing pages to use the new `Section` component
- Fixed a broken link in the freecyclery page and fixed issues with capitalization, spacing, and text size in the classes page